### PR TITLE
Allow tuning NEAT hyperparameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,20 @@ from train import train_slime
 from utils import rollout_frames, save_gif
 
 # Train for a few generations (increase for better performance)
-best = train_slime(pop_size=20, n_generations=10, max_steps=1000)
+best = train_slime(
+    pop_size=20,
+    n_generations=10,
+    max_steps=1000,
+    neat_kwargs={"mutate_weight_prob": 0.9}
+)
 
 # Roll the trained genome and save a gif
 frames = rollout_frames(best, steps=400, frame_skip=5)
 save_gif(frames, 'slime.gif')
 ```
+
+The optional ``neat_kwargs`` argument allows you to tweak NEAT
+hyper-parameters such as mutation rates.
 
 This will produce a file `slime.gif` which can be displayed directly in Colab
 or downloaded.

--- a/train.py
+++ b/train.py
@@ -38,8 +38,11 @@ def train_slime(
     pop_size: int = 20,
     n_generations: int = 10,
     max_steps: int = 1000,
+    neat_kwargs: dict | None = None,
 ) -> Genome:
     """Train a NEAT population on the SlimeVolley task.
+
+    Additional NEAT hyper-parameters can be provided via ``neat_kwargs``.
 
     Returns the best genome after ``n_generations``.
     """
@@ -50,7 +53,12 @@ def train_slime(
     template = Genome(obs_dim, 8, tbl)
 
     evaluate_fn = _evaluate_factory(task)
-    neat = NEAT(pop_size=pop_size, genome_template=template, evaluate_fn=evaluate_fn)
+    if neat_kwargs is None:
+        neat_kwargs = {}
+    neat = NEAT(pop_size=pop_size,
+                genome_template=template,
+                evaluate_fn=evaluate_fn,
+                **neat_kwargs)
     neat.evolve(n_generations)
     return neat.best_genome
 


### PR DESCRIPTION
## Summary
- allow NEAT mutation and compatibility parameters to be configured
- expose optional `neat_kwargs` in `train_slime`
- document example usage in README

## Testing
- `python -m py_compile genome.py neat.py slimevolly.py train.py utils.py`